### PR TITLE
fix: config-tool cannot be opened when the Control Center dbus API call fails

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -57,6 +57,7 @@ Depends:
  libfcitx5config6 (= ${binary:Version}),
  libfcitx5core7 (= ${binary:Version}),
  libfcitx5utils2 (= ${binary:Version}),
+ jq,
  ${misc:Depends},
  ${shlibs:Depends},
 Recommends:

--- a/debian/patches/0005-configtool-opens-dde-control-center-when-using-DDE.patch
+++ b/debian/patches/0005-configtool-opens-dde-control-center-when-using-DDE.patch
@@ -40,7 +40,7 @@ index 4daf97a..6251da9 100755
 +    local dbus_interface="org.deepin.dde.ControlCenter1"
 +    local dcc_module="keyboard/Manage Input Methods"
 +
-+    if dbus-send --print-reply=literal --dest=$dbus_service $dbus_path $dbus_interface.GetAllModule | jq -e ".[] | select(.url == \"${dcc_module}\")" >> /dev/null 2>&1; then
++    if dbus-send --print-reply=literal --dest=$dbus_service $dbus_path $dbus_interface.GetAllModule 2>> /dev/null | jq --arg url "$dcc_module" -Rse 'fromjson? // error("Bad input") | any(.url == $url)' >> /dev/null 2>&1; then
 +        exec dbus-send --print-reply=literal --dest=$dbus_service $dbus_path $dbus_interface.ShowPage string:"$dcc_module"
 +    fi
 +    return 1


### PR DESCRIPTION
Modify the parameters of the jq command to
handle invalid JSON format inputs.

Fixes linuxdeepin/developer-center#3659