### PR TITLE
bump version to 5.1.5-1deepin3

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+fcitx5 (5.1.5-1deepin3) unstable; urgency=medium
+
+  * fix #7815
+
+ -- Mike Chen <chenke@deepin.org>  Fri, 12 Apr 2024 10:17:51 +0800
+
 fcitx5 (5.1.5-1deepin2) unstable; urgency=medium
 
   * Add deepin patchs.

--- a/debian/patches/0006-Revert-disable-ctrl-shift-enumerate-key-by-default.patch
+++ b/debian/patches/0006-Revert-disable-ctrl-shift-enumerate-key-by-default.patch
@@ -1,0 +1,21 @@
+diff --git a/src/lib/fcitx/globalconfig.cpp b/src/lib/fcitx/globalconfig.cpp
+index 49946c51..8c4c0e64 100644
+--- a/src/lib/fcitx/globalconfig.cpp
++++ b/src/lib/fcitx/globalconfig.cpp
+@@ -50,14 +50,14 @@ FCITX_CONFIGURATION(
+         this,
+         "EnumerateForwardKeys",
+         _("Enumerate Input Method Forward"),
+-        {},
++        {Key("Control+Shift_L")},
+         KeyListConstrain({KeyConstrainFlag::AllowModifierLess,
+                           KeyConstrainFlag::AllowModifierOnly})};
+     KeyListOption enumerateBackwardKeys{
+         this,
+         "EnumerateBackwardKeys",
+         _("Enumerate Input Method Backward"),
+-        {},
++        {Key("Control+Shift_R")},
+         KeyListConstrain({KeyConstrainFlag::AllowModifierLess,
+                           KeyConstrainFlag::AllowModifierOnly})};
+     Option<bool> enumerateSkipFirst{

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,3 +1,4 @@
 0001-fix-kde-config-fcitx5-package-name-in-fcitx5-configt.patch
 0002-For-lower-versions-gcc-compatible.patch
 0005-configtool-opens-dde-control-center-when-using-DDE.patch
+0006-Revert-disable-ctrl-shift-enumerate-key-by-default.patch


### PR DESCRIPTION
fix: default enumerate key none

revert https://github.com/fcitx/fcitx5/commit/617c8c65

Issue: https://github.com/linuxdeepin/developer-center/issues/7815