### PR TITLE
fix: remove the restart icon

### DIFF
--- a/src/modules/notificationitem/dbusmenu.cpp
+++ b/src/modules/notificationitem/dbusmenu.cpp
@@ -259,8 +259,8 @@ void DBusMenu::fillLayoutProperties(
         case BII_Restart:
             appendProperty(properties, propertyNames, "label",
                            dbus::Variant(_("Restart")));
-            appendProperty(properties, propertyNames, "icon-name",
-                           dbus::Variant("view-refresh"));
+            // appendProperty(properties, propertyNames, "icon-name",
+            //                dbus::Variant("view-refresh"));
             break;
         case BII_Exit:
             appendProperty(properties, propertyNames, "label",


### PR DESCRIPTION
Remove the restart icon from the right-click menu

Log: remove the restart icon
Bug: https://pms.uniontech.com/bug-view-270971.html