### PR TITLE
fix: remove the restart icon

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+fcitx5 (5.1.10-1deepin5) unstable; urgency=medium
+
+  * remove the restart icon from the right-click menu
+
+ -- xionglinlin <xionglinlin@uniontech.com>  Wed, 16 Oct 2024 16:25:33 +0800
+
 fcitx5 (5.1.10-1deepin4) unstable; urgency=medium
 
   * Use gcc 12.

--- a/debian/patches/0008-fix-remove-the-restart-icon.patch
+++ b/debian/patches/0008-fix-remove-the-restart-icon.patch
@@ -1,0 +1,25 @@
+From: xionglinlin <xionglinlin@uniontech.com>
+Date: Sun, 29 Sep 2024 11:44:52 +0800
+Subject: fix: remove the restart icon
+
+remove the restart icon from the right-click menu
+
+Log: remove the restart icon
+Bug: https://pms.uniontech.com/bug-view-270971.html
+---
+ src/modules/notificationitem/dbusmenu.cpp | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/src/modules/notificationitem/dbusmenu.cpp b/src/modules/notificationitem/dbusmenu.cpp
+index 10e33c5..e29409f 100644
+--- a/src/modules/notificationitem/dbusmenu.cpp
++++ b/src/modules/notificationitem/dbusmenu.cpp
+@@ -259,8 +259,6 @@ void DBusMenu::fillLayoutProperties(
+         case BII_Restart:
+             appendProperty(properties, propertyNames, "label",
+                            dbus::Variant(_("Restart")));
+-            appendProperty(properties, propertyNames, "icon-name",
+-                           dbus::Variant("view-refresh"));
+             break;
+         case BII_Exit:
+             appendProperty(properties, propertyNames, "label",

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -3,3 +3,4 @@
 0005-configtool-opens-dde-control-center-when-using-DDE.patch
 0006-Revert-disable-ctrl-shift-enumerate-key-by-default.patch
 0007-Add-Sogou-to-the-default-zh_CN-input-method-list.patch
+0008-fix-remove-the-restart-icon.patch


### PR DESCRIPTION
remove the restart icon from the right-click menu

Log: remove the restart icon
Bug: https://pms.uniontech.com/bug-view-270971.html