### PR TITLE
fix: Sogou input method shift fails to switch between Chinese and Eng…

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+fcitx5 (5.1.10-1deepin8) unstable; urgency=medium
+
+  * Disable the default shortcut key for altTriggerKeys
+
+ -- Wang Yu <wangyu@uniontech.com>  Tue, 10 Dec 2024 10:38:37 +0800
+
 fcitx5 (5.1.10-1deepin7) unstable; urgency=medium
 
   * Processing Deepin25 Jump Control Center

--- a/debian/patches/0010-disable-the-default-shortcut-key-for-altTriggerKeys.patch
+++ b/debian/patches/0010-disable-the-default-shortcut-key-for-altTriggerKeys.patch
@@ -1,0 +1,13 @@
+Index: fcitx5/src/lib/fcitx/globalconfig.cpp
+===================================================================
+--- fcitx5.orig/src/lib/fcitx/globalconfig.cpp
++++ fcitx5/src/lib/fcitx/globalconfig.cpp
+@@ -43,7 +43,7 @@ FCITX_CONFIGURATION(
+         this,
+         "AltTriggerKeys",
+         _("Temporally switch between first and current Input Method"),
+-        {Key("Shift_L")},
++        {},
+         KeyListConstrain({KeyConstrainFlag::AllowModifierLess,
+                           KeyConstrainFlag::AllowModifierOnly})};
+     KeyListOption enumerateForwardKeys{

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -5,3 +5,4 @@
 0007-Add-Sogou-to-the-default-zh_CN-input-method-list.patch
 0008-fix-remove-the-restart-icon.patch
 0009-configtool-opens-dde-control-center-when-using-deepin25.patch
+0010-disable-the-default-shortcut-key-for-altTriggerKeys.patch


### PR DESCRIPTION
Disable the default shortcut key of altTriggerKeys

Log: Sogou input method shift fails to switch between Chinese and English
pms: BUG-288893