### PR TITLE
fix: improve -r flag handling in fcitx5-start script

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+fcitx5 (5.1.11-2deepin5) unstable; urgency=medium
+
+  * improve -r flag handling in fcitx5-start script
+
+ -- Wang Yu <wangyu@uniontch.com>  Wed, 09 Apr 2025 10:40:27 +0800
+
 fcitx5 (5.1.11-2deepin4) unstable; urgency=medium
 
   * add log management for fcitx5-start script.

--- a/debian/patches/0011-add-log-management-for-fcitx5-start-script.patch
+++ b/debian/patches/0011-add-log-management-for-fcitx5-start-script.patch
@@ -24,7 +24,7 @@ Index: fcitx5-community/data/fcitx5-start.sh
 ===================================================================
 --- /dev/null
 +++ fcitx5-community/data/fcitx5-start.sh
-@@ -0,0 +1,44 @@
+@@ -0,0 +1,45 @@
 +#!/usr/bin/env bash
 +
 +# Log management function
@@ -48,16 +48,17 @@ Index: fcitx5-community/data/fcitx5-start.sh
 +
 +run_fcitx5() {
 +    if which fcitx5 > /dev/null 2>&1; then
-+        # If fcitx5 is running and no -r flag, try to force kill it first
-+        if pgrep -u "$USER" fcitx5 >/dev/null && [[ ! "$@" =~ "-r" ]]; then
-+            pkill -9 -u "$USER" fcitx5
-+            sleep 0.1  # Give some time for the process to be killed
-+            # If process still exists, use -r flag
-+            if pgrep -u "$USER" fcitx5 >/dev/null; then
++        # Check if fcitx5 is running
++        if pgrep -u "$USER" fcitx5 >/dev/null; then
++            # If -r flag doesn't exist in args (either alone or in combinations like -rd, -dr), add it
++            if [[ ! "$*" =~ (^|-)[[:space:]]*[a-z]*r[a-z]* ]]; then
 +                exec fcitx5 -r "$@" >> "$FCITX_LOG" 2>&1
++            else
++                exec fcitx5 "$@" >> "$FCITX_LOG" 2>&1
 +            fi
++        else
++            exec fcitx5 "$@" >> "$FCITX_LOG" 2>&1
 +        fi
-+        exec fcitx5 "$@" >> "$FCITX_LOG" 2>&1
 +    fi
 +}
 +


### PR DESCRIPTION
- Optimize -r flag detection with regex pattern matching
- Remove force kill behavior in favor of smarter process handling
- Improve process state detection logic

Log: improve -r flag handling in fcitx5-start script
pms: BUG-311649