### PR TITLE
fix: unify ShareInputState behavior across platforms

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+fcitx5 (5.1.11-2deepin7) unstable; urgency=medium
+
+  * unify ShareInputState behavior across platforms
+
+ -- Wang Yu <wangyu@uniontch.com>  Thu, 12 Jun 2025 11:34:40 +0800
+
 fcitx5 (5.1.11-2deepin6) unstable; urgency=medium
 
   * remove send event to topLevel flag

--- a/debian/patches/0013-fix-unify-shareInputstate-behavior-across-platforms.patch
+++ b/debian/patches/0013-fix-unify-shareInputstate-behavior-across-platforms.patch
@@ -1,0 +1,14 @@
+Index: fcitx5-community/src/lib/fcitx/globalconfig.cpp
+===================================================================
+--- fcitx5-community.orig/src/lib/fcitx/globalconfig.cpp
++++ fcitx5-community/src/lib/fcitx/globalconfig.cpp
+@@ -146,8 +146,7 @@ FCITX_CONFIGURATION(
+     OptionWithAnnotation<PropertyPropagatePolicy,
+                          PropertyPropagatePolicyI18NAnnotation>
+         shareState{this, "ShareInputState", _("Share Input State"),
+-                   isAndroid() ? PropertyPropagatePolicy::All
+-                               : PropertyPropagatePolicy::No};
++                   PropertyPropagatePolicy::All};
+     Option<bool> preeditEnabledByDefault{this, "PreeditEnabledByDefault",
+                                          _("Show preedit in application"),
+                                          true};

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -7,3 +7,4 @@
 0010-disable-the-default-shortcut-key-for-altTriggerKeys.patch
 0011-add-log-management-for-fcitx5-start-script.patch
 0012-remove-send-event-to-topLevel-flag.patch
+0013-fix-unify-shareInputstate-behavior-across-platforms.patch


### PR DESCRIPTION
- Removed Android-specific conditional logic for ShareInputState property.
- Changed to always use PropertyPropagatePolicy::All instead of platform-dependent values.

Log: unify ShareInputState behavior across platforms
pms: BUG-314609