### PR TITLE
fix: update default shortcut key for altTriggerKeys in fcitx5

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+fcitx5 (5.1.11-2deepin8) unstable; urgency=medium
+
+  * update default shortcut key for altTriggerKeys in fcitx5
+
+ -- Wang Yu <wangyu@uniontch.com>  Mon, 16 Jun 2025 14:02:37 +0800
+
 fcitx5 (5.1.11-2deepin7) unstable; urgency=medium
 
   * unify ShareInputState behavior across platforms

--- a/debian/patches/0010-update-the-default-shortcut-key-for-altTriggerKeys.patch
+++ b/debian/patches/0010-update-the-default-shortcut-key-for-altTriggerKeys.patch
@@ -7,7 +7,7 @@ Index: fcitx5/src/lib/fcitx/globalconfig.cpp
          "AltTriggerKeys",
          _("Temporally switch between first and current Input Method"),
 -        {Key("Shift_L")},
-+        {},
++        {Key("Control+Shift+space")},
          KeyListConstrain({KeyConstrainFlag::AllowModifierLess,
                            KeyConstrainFlag::AllowModifierOnly})};
      KeyListOption enumerateForwardKeys{

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -4,7 +4,7 @@
 0007-Add-Sogou-to-the-default-zh_CN-input-method-list.patch
 0008-fix-remove-the-restart-icon.patch
 0009-configtool-opens-dde-control-center-when-using-deepin25.patch
-0010-disable-the-default-shortcut-key-for-altTriggerKeys.patch
+0010-update-the-default-shortcut-key-for-altTriggerKeys.patch
 0011-add-log-management-for-fcitx5-start-script.patch
 0012-remove-send-event-to-topLevel-flag.patch
 0013-fix-unify-shareInputstate-behavior-across-platforms.patch


### PR DESCRIPTION
- Changed altTriggerKeys from disabled (empty) to Control+Shift+space for better user experience.

Log: update default shortcut key for altTriggerKeys in fcitx5
pms: BUG-316129