### PR TITLE
fix: update Sogou input method entry in zh_CN list

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+fcitx5 (5.1.12-2deepin2) unstable; urgency=medium
+
+  * d/rules: apply UOS-only patch to override Sogou default entry.
+  * debian/patches: add 0014-uos-override-sogou-for-uos.patch.
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Mon, 30 Mar 2026 19:41:55 +0800
+
 fcitx5 (5.1.12-2deepin1) unstable; urgency=medium
 
   * Merge patches from master branch.

--- a/debian/control
+++ b/debian/control
@@ -45,6 +45,7 @@ Build-Depends:
  unicode-cldr-core,
  uuid-dev,
  wayland-protocols [linux-any],
+ lsb-release
 Standards-Version: 4.7.2
 Rules-Requires-Root: no
 Homepage: https://github.com/fcitx/fcitx5

--- a/debian/patches/0014-uos-override-sogou-for-uos.patch
+++ b/debian/patches/0014-uos-override-sogou-for-uos.patch
@@ -1,0 +1,14 @@
+From: UnionTech <packaging@uniontech.com>
+Date: Mon, 30 Mar 2026 20:40:00 +0800
+Subject: UOS: use sogou uos in default zh_CN list
+
+Only override the appended input method for UOS builds.
+
+Index: fcitx5-community/data/default/zh_CN
+===================================================================
+--- fcitx5-community.orig/data/default/zh_CN
++++ fcitx5-community/data/default/zh_CN
+@@ -5,2 +5,2 @@
+ [AppendInputMethods]
+-0=com.sogou.ime.ng.fcitx5.deepin
++0=com.sogou.ime.ng.fcitx5.uos

--- a/debian/rules
+++ b/debian/rules
@@ -8,10 +8,26 @@ ifneq (linux,$(DEB_HOST_ARCH_OS))
 config-opt += -DUSE_SYSTEMD=OFF -DENABLE_WAYLAND=OFF
 endif
 
+ifeq (,$(filter uos Uos UOS,$(shell lsb_release -i -s)))
+    DEBUG_SHELL_FLAG = /usr/bin/bash
+    UOS_SYSTEM = no
+else
+    DEBUG_SHELL_FLAG = "/sbin/agetty -o '-p -- \\\\\\\\u' --noclear - linux"
+    UOS_SYSTEM = yes
+endif
+
 %:
 	dh $@
 
 override_dh_auto_configure:
+ifeq (yes,$(UOS_SYSTEM))
+	if patch -p1 --dry-run -R < debian/patches/0014-uos-override-sogou-for-uos.patch >/dev/null 2>&1; then \
+		echo "UOS: sogou uos patch already applied, skipping"; \
+	else \
+		echo "UOS: applying sogou uos override patch"; \
+		patch -p1 < debian/patches/0014-uos-override-sogou-for-uos.patch; \
+	fi
+endif
 	dh_auto_configure -- $(config-opt)
 
 override_dh_auto_test:


### PR DESCRIPTION
- Changed Sogou input method identifier from 'com.sogou.ime.ng.fcitx5.deepin' to 'com.sogou.ime.ng.fcitx5.uos' in the default input method list for zh_CN.

Log: Update Sogou input method entry to reflect new identifier.