### PR TITLE
fix: add enumerate key bindings and disable input method info popup

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+fcitx5 (5.1.12-2deepin3) unstable; urgency=medium
+
+  * debian/patches: add 0015-disable-showInputMethodInformation-by-default.patch.
+  * debian/patches: update enumerate key bindings with Control_L/R support.
+  * Disable ShowInputMethodInformation popup by default.
+
+ -- Wang Yu <wangyu@uniontech.com>  Thu, 16 Apr 2026 21:26:20 +0800
+
 fcitx5 (5.1.12-2deepin2) unstable; urgency=medium
 
   * d/rules: apply UOS-only patch to override Sogou default entry.

--- a/debian/patches/0003-Revert-disable-ctrl-shift-enumerate-key-by-default.patch
+++ b/debian/patches/0003-Revert-disable-ctrl-shift-enumerate-key-by-default.patch
@@ -7,7 +7,7 @@ Index: fcitx5-community/src/lib/fcitx/globalconfig.cpp
          "EnumerateForwardKeys",
          _("Enumerate Input Method Forward"),
 -        {},
-+        {Key("Control+Shift_L")},
++        {Key("Control+Shift_L"), Key("Control+Shift+Control_L")},
          KeyListConstrain({KeyConstrainFlag::AllowModifierLess,
                            KeyConstrainFlag::AllowModifierOnly})};
      KeyListOption enumerateBackwardKeys{
@@ -15,7 +15,7 @@ Index: fcitx5-community/src/lib/fcitx/globalconfig.cpp
          "EnumerateBackwardKeys",
          _("Enumerate Input Method Backward"),
 -        {},
-+        {Key("Control+Shift_R")},
++        {Key("Control+Shift_R"), Key("Control+Shift+Control_R")},
          KeyListConstrain({KeyConstrainFlag::AllowModifierLess,
                            KeyConstrainFlag::AllowModifierOnly})};
      Option<bool> enumerateSkipFirst{

--- a/debian/patches/0015-disable-showInputMethodInformation-by-default.patch
+++ b/debian/patches/0015-disable-showInputMethodInformation-by-default.patch
@@ -1,0 +1,13 @@
+Index: fcitx5-community/src/lib/fcitx/globalconfig.cpp
+===================================================================
+--- fcitx5-community.orig/src/lib/fcitx/globalconfig.cpp
++++ fcitx5-community/src/lib/fcitx/globalconfig.cpp
+@@ -174,7 +174,7 @@ FCITX_CONFIGURATION(
+                                          true};
+     Option<bool> showInputMethodInformation{
+         this, "ShowInputMethodInformation",
+-        _("Show Input Method Information when switch input method"), true};
++        _("Show Input Method Information when switch input method"), false};
+     Option<bool> showInputMethodInformationWhenFocusIn{
+         this, "showInputMethodInformationWhenFocusIn",
+         _("Show Input Method Information when changing focus"), false};

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -11,3 +11,4 @@
 0011-default_la.patch
 0012-Added-lo-po-translation.patch
 0013-hide-fcitx5-desktop-in-the-start-menu.patch
+0015-disable-showInputMethodInformation-by-default.patch


### PR DESCRIPTION
Add Control+Shift+Control_L/R as enumerate key bindings alongside existing shortcuts. Disable ShowInputMethodInformation by default.

为输入法切换快捷键增加 Control+Shift+Control_L/R 绑定，
默认关闭切换输入法时的输入法信息提示弹窗。

Log: 增加切换快捷键绑定并默认关闭输入法信息弹窗
PMS: BUG-357563
Influence: 用户切换输入法时不再默认弹出输入法名称提示，同时支持更多切换快捷键组合。