### PR TITLE
fix: only use first XKB layout for default group

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+fcitx5 (5.1.12-2deepin4) unstable; urgency=medium
+
+  * debian/patches: add 0016-only-use-first-xkb-layout-for-default-group.patch.
+  * Only use the first XKB layout when building default input method group.
+
+ -- Wang Yu <wangyu@uniontech.com>  Wed, 23 Apr 2026 10:00:00 +0800
+
 fcitx5 (5.1.12-2deepin3) unstable; urgency=medium
 
   * debian/patches: add 0015-disable-showInputMethodInformation-by-default.patch.

--- a/debian/patches/0016-only-use-first-xkb-layout-for-default-group.patch
+++ b/debian/patches/0016-only-use-first-xkb-layout-for-default-group.patch
@@ -1,0 +1,32 @@
+From: Wang Yu <wangyu@uniontech.com>
+Date: Mon, 21 Apr 2026 00:00:00 +0800
+Subject: Only use the first XKB layout for default group
+
+When the system has multiple XKB layouts configured (e.g. "us,cn"),
+buildDefaultGroup() would create multiple input method groups. This
+patch makes it only use the first layout to avoid creating unnecessary
+groups.
+
+---
+ src/lib/fcitx/instance.cpp | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/src/lib/fcitx/instance.cpp b/src/lib/fcitx/instance.cpp
+index d23a957..7ac9b78 100644
+--- a/src/lib/fcitx/instance.cpp
++++ b/src/lib/fcitx/instance.cpp
+@@ -271,8 +271,12 @@ void InstancePrivate::buildDefaultGroup() {
+         if (xcb) {
+             auto rules = xcb->call<IXCBModule::xkbRulesNames>(x11Name);
+             if (!rules[2].empty()) {
+-                layouts = rules[2];
+-                variants = rules[3];
++                auto layoutList =
++                    stringutils::split(rules[2], ",", stringutils::SplitBehavior::KeepEmpty);
++                auto variantList =
++                    stringutils::split(rules[3], ",", stringutils::SplitBehavior::KeepEmpty);
++                layouts = layoutList.empty() ? "" : layoutList[0];
++                variants = variantList.empty() ? "" : variantList[0];
+                 infoFound = true;
+                 return false;
+             }

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -12,3 +12,4 @@
 0012-Added-lo-po-translation.patch
 0013-hide-fcitx5-desktop-in-the-start-menu.patch
 0015-disable-showInputMethodInformation-by-default.patch
+0016-only-use-first-xkb-layout-for-default-group.patch


### PR DESCRIPTION
When multiple XKB layouts are configured, only use the first one to avoid creating unnecessary input method groups on first startup.

当系统配置了多个XKB布局时，首次启动只使用第一个布局，
避免创建多余的输入法分组。

Log: 只取第一个XKB布局作为默认分组
PMS: BUG-357551
Influence: 首次启动不再因系统多布局配置产生多余的输入法分组