### PR TITLE
fix: detect DDE desktop type for XDG_CURRENT_DESKTOP=DDE

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+fcitx5 (5.1.12-2deepin5) unstable; urgency=medium
+
+  * debian/patches: add 0017-fix-detect-dde-desktop-type-for-XDG_CURRENT_DESKTOP-DDE.patch.
+  * Fix DDE desktop type detection when XDG_CURRENT_DESKTOP=DDE.
+
+ -- Wang Yu <wangyu@uniontech.com>  Sun, 27 Apr 2026 10:00:00 +0800
+
 fcitx5 (5.1.12-2deepin4) unstable; urgency=medium
 
   * debian/patches: add 0016-only-use-first-xkb-layout-for-default-group.patch.

--- a/debian/patches/0017-fix-detect-dde-desktop-type-for-XDG_CURRENT_DESKTOP-DDE.patch
+++ b/debian/patches/0017-fix-detect-dde-desktop-type-for-XDG_CURRENT_DESKTOP-DDE.patch
@@ -1,0 +1,20 @@
+Description: Fix DDE desktop type detection when XDG_CURRENT_DESKTOP=DDE
+ DDE sets XDG_CURRENT_DESKTOP to "DDE" (not "Deepin"), which was not
+ recognized by getDesktopType(). This caused the exit menu item to appear
+ on DDE despite being intended to be hidden.
+ .
+ Use starts_with("dde") to match "dde" and any "DDE:xxx" multi-value formats.
+Author: Wang Yu <wangyu@uniontech.com>
+Last-Update: 2026-04-24
+
+--- fcitx5-community.orig/src/lib/fcitx/misc_p.h
++++ fcitx5-community/src/lib/fcitx/misc_p.h
+@@ -168,7 +168,7 @@ static inline DesktopType getDesktopType
+             return DesktopType::GNOME;
+         } else if (desktop == "xfce") {
+             return DesktopType::XFCE;
+-        } else if (desktop == "deepin") {
++        } else if (desktop == "deepin" || stringutils::startsWith(desktop, "dde")) {
+             return DesktopType::DEEPIN;
+         } else if (desktop == "ukui") {
+             return DesktopType::UKUI;

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -13,3 +13,4 @@
 0013-hide-fcitx5-desktop-in-the-start-menu.patch
 0015-disable-showInputMethodInformation-by-default.patch
 0016-only-use-first-xkb-layout-for-default-group.patch
+0017-fix-detect-dde-desktop-type-for-XDG_CURRENT_DESKTOP-DDE.patch


### PR DESCRIPTION
DDE sets XDG_CURRENT_DESKTOP to "DDE" instead of "Deepin", use stringutils::startsWith to match both formats.

修复DDE桌面环境类型检测，支持 XDG_CURRENT_DESKTOP=DDE 的场景。

Log: 修复DDE桌面类型检测，隐藏退出菜单项
PMS: TASK-388907
Influence: 修复后DDE环境下fcitx5托盘右键菜单不再显示"退出"选项。