### PR TITLE
feat(notificationitem): show input method name in SNI tooltip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ cscope.*
 XF86keysym.h
 keysymdef.h
 *~
+AGENTS.md

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+fcitx5 (5.1.12-2deepin6) unstable; urgency=medium
+
+  * debian/patches: add 0018-show-current-input-method-name-in-sni-tooltip.patch.
+  * Show current input method name in SNI tooltip.
+
+ -- Wang Yu <wangyu@uniontech.com>  Tue, 16 Jun 2026 11:20:28 +0800
+
 fcitx5 (5.1.12-2deepin5) unstable; urgency=medium
 
   * debian/patches: add 0017-fix-detect-dde-desktop-type-for-XDG_CURRENT_DESKTOP-DDE.patch.

--- a/debian/patches/0018-show-current-input-method-name-in-sni-tooltip.patch
+++ b/debian/patches/0018-show-current-input-method-name-in-sni-tooltip.patch
@@ -1,0 +1,369 @@
+Description: Show current input method name in SNI tooltip
+ The StatusNotifierItem tooltip() previously returned an empty struct, so
+ the dock/tray icon showed no tooltip text on hover. tooltip() now returns
+ the current input method name as the tooltip title, with a debounced
+ NewToolTip signal emitted on input method switch, focus change, and input
+ method group change.
+ .
+ This patch is a squash of multiple upstream commits on the
+ fix/sni-tooltip-input-method-name branch (6ac6ae22 / d64071c5 /
+ ba959171 / e74e9fd1 / 7c83dc86 / c9f9cf0a / 4c0007cc, PR #1578),
+ applied against the 5.1.12 baseline. It also carries the incidental
+ cleanups from those commits (include reorganization,
+ title()/iconPixmap() refactoring) so the result tracks upstream master.
+ .
+ The upstream std::ranges::transform change in scroll() is dropped to
+ stay compatible with the project's C++17 build standard.
+Origin: upstream, https://github.com/fcitx/fcitx5/pull/1578
+Author: Wang Yu <wangyu@uniontech.com>
+Last-Update: 2026-06-16
+
+--- fcitx5-community.orig/src/modules/notificationitem/notificationitem.cpp
++++ fcitx5-community/src/modules/notificationitem/notificationitem.cpp
+@@ -7,17 +7,35 @@
+
+ #include "notificationitem.h"
+ #include <unistd.h>
++#include <algorithm>
++#include <cstddef>
++#include <cstdint>
++#include <memory>
++#include <string>
++#include <utility>
++#include <vector>
+ #include "fcitx-utils/charutils.h"
+ #include "fcitx-utils/dbus/message.h"
+ #include "fcitx-utils/dbus/objectvtable.h"
++#include "fcitx-utils/dbus/servicewatcher.h"
+ #include "fcitx-utils/endian_p.h"
++#include "fcitx-utils/eventloopinterface.h"
++#include "fcitx-utils/handlertable.h"
+ #include "fcitx-utils/i18n.h"
++#include "fcitx-utils/log.h"
+ #include "fcitx/addonfactory.h"
+ #include "fcitx/addoninstance.h"
+ #include "fcitx/addonmanager.h"
++#include "fcitx/event.h"
++#include "fcitx/icontheme.h"
++#include "fcitx/inputmethodentry.h"
++#include "fcitx/instance.h"
+ #include "fcitx/misc_p.h"
++#include "fcitx/userinterface.h"
+ #include "classicui_public.h"
++#include "dbus_public.h"
+ #include "dbusmenu.h"
++#include "notificationitem_public.h"
+
+ #define NOTIFICATION_ITEM_DBUS_IFACE "org.kde.StatusNotifierItem"
+ #define NOTIFICATION_ITEM_DEFAULT_OBJ "/StatusNotifierItem"
+@@ -26,10 +44,15 @@
+ #define NOTIFICATION_WATCHER_DBUS_IFACE "org.kde.StatusNotifierWatcher"
+ #define DBUS_MENU_IFACE "com.canonical.dbusmenu"
+
+-FCITX_DEFINE_LOG_CATEGORY(notificationitem, "notificationitem");
+ #define SNI_DEBUG() FCITX_LOGC(::notificationitem, Debug)
+ #define SNI_ERROR() FCITX_LOGC(::notificationitem, Error)
+
++namespace {
++
++FCITX_DEFINE_LOG_CATEGORY(notificationitem, "notificationitem");
++
++}
++
+ namespace fcitx {
+
+ class StatusNotifierItem : public dbus::ObjectVTable<StatusNotifierItem> {
+@@ -53,14 +76,15 @@ public:
+             deltaAcc_ += 120;
+         }
+     }
+-    void activate(int, int) { parent_->instance()->toggle(); }
+-    void secondaryActivate(int, int) {}
++    void activate(int /*unused*/, int /*unused*/) {
++        parent_->instance()->toggle();
++    }
++    void secondaryActivate(int /*unused*/, int /*unused*/) {}
+     std::string keyboardIconName() const {
+         if (isKDE()) {
+             return "input-keyboard";
+-        } else {
+-            return "input-keyboard-symbolic";
+         }
++        return "input-keyboard-symbolic";
+     }
+     std::string iconName() {
+         std::string icon;
+@@ -76,19 +100,39 @@ public:
+         return IconTheme::iconName(icon);
+     }
+
++    std::string iconNamePropertyImpl() {
++        std::string label;
++        std::string icon;
++        if (auto *ic = parent_->menu()->lastRelevantIc()) {
++            label = parent_->instance()->inputMethodLabel(ic);
++            icon = parent_->instance()->inputMethodIcon(ic);
++        }
++        return preferTextIcon(label, icon) ? "" : iconName();
++    }
++
+     std::string label() { return ""; }
+
+-    static dbus::DBusStruct<
++    std::string title() { return _("Input Method"); }
++
++    dbus::DBusStruct<
+         std::string,
+         std::vector<dbus::DBusStruct<int32_t, int32_t, std::vector<uint8_t>>>,
+         std::string, std::string>
+     tooltip() {
+-        return {};
++
++        const InputMethodEntry *imEntry = nullptr;
++        if (auto *ic = parent_->menu()->lastRelevantIc()) {
++            imEntry = parent_->instance()->inputMethodEntry(ic);
++        }
++        std::string title =
++            imEntry == nullptr ? _("Input Method") : imEntry->name();
++        return {iconNamePropertyImpl(), iconPixmap(), std::move(title),
++                std::string()};
+     }
+
+     bool preferTextIcon(const std::string &label,
+                         const std::string &icon) const {
+-        auto classicui = parent_->classicui();
++        auto *classicui = parent_->classicui();
+         return classicui && !label.empty() &&
+                ((icon == "input-keyboard" &&
+                  classicui->call<IClassicUI::showLayoutNameInIcon>() &&
+@@ -110,6 +154,16 @@ public:
+         lastLabel_ = std::move(label);
+     }
+
++    void notifyNewTooltip() {
++        auto currentTooltip = tooltip();
++        const auto &tipTitle = std::get<2>(currentTooltip);
++        if (tipTitle.empty() || lastTitle_ == tipTitle) {
++            return;
++        }
++        newToolTip();
++        lastTitle_ = tipTitle;
++    }
++
+     void reset() {
+         releaseSlot();
+         lastIconName_.clear();
+@@ -117,7 +171,8 @@ public:
+     }
+
+     std::string labelText() const {
+-        std::string label, icon;
++        std::string label;
++        std::string icon;
+         if (auto *ic = parent_->menu()->lastRelevantIc()) {
+             label = parent_->instance()->inputMethodLabel(ic);
+             icon = parent_->instance()->inputMethodIcon(ic);
+@@ -128,6 +183,41 @@ public:
+         return label;
+     }
+
++    // Update the cached icon pixmap, return whether we have a valid icon.
++    bool updateCachedIconPixmap() {
++        auto *classicui = parent_->classicui();
++        if (!classicui) {
++            return false;
++        }
++        std::vector<dbus::DBusStruct<int, int, std::vector<uint8_t>>> result;
++        const auto label = labelText();
++        if (!label.empty() && cachedLabel_ != label) {
++            for (unsigned int size : {16, 22, 32, 48}) {
++                // swap to network byte order if we are little endian
++                auto data = classicui->call<IClassicUI::labelIcon>(label, size);
++                if (isLittleEndian()) {
++                    auto *uintBuf = reinterpret_cast<uint32_t *>(data.data());
++                    for (size_t i = 0; i < data.size() / sizeof(uint32_t);
++                         ++i) {
++                        *uintBuf = htobe32(*uintBuf);
++                        ++uintBuf;
++                    }
++                }
++                result.emplace_back(size, size, std::move(data));
++            }
++            cachedLabel_ = label;
++            cachedLabelIcon_ = result;
++        }
++        return !cachedLabel_.empty();
++    }
++
++    std::vector<dbus::DBusStruct<int, int, std::vector<uint8_t>>> iconPixmap() {
++        if (updateCachedIconPixmap()) {
++            return cachedLabelIcon_;
++        }
++        return {};
++    }
++
+     FCITX_OBJECT_VTABLE_METHOD(scroll, "Scroll", "is", "");
+     FCITX_OBJECT_VTABLE_METHOD(activate, "Activate", "ii", "");
+     FCITX_OBJECT_VTABLE_METHOD(secondaryActivate, "SecondaryActivate", "ii",
+@@ -145,54 +235,14 @@ public:
+                                  []() { return "SystemServices"; });
+     FCITX_OBJECT_VTABLE_PROPERTY(id, "Id", "s", []() { return "Fcitx"; });
+     FCITX_OBJECT_VTABLE_PROPERTY(title, "Title", "s",
+-                                 []() { return _("Input Method"); });
++                                 [this]() { return title(); });
+     FCITX_OBJECT_VTABLE_PROPERTY(status, "Status", "s",
+                                  []() { return "Active"; });
+     FCITX_OBJECT_VTABLE_PROPERTY(windowId, "WindowId", "i", []() { return 0; });
+-    FCITX_OBJECT_VTABLE_PROPERTY(
+-        iconName, "IconName", "s", ([this]() {
+-            std::string label, icon;
+-            if (auto *ic = parent_->menu()->lastRelevantIc()) {
+-                label = parent_->instance()->inputMethodLabel(ic);
+-                icon = parent_->instance()->inputMethodIcon(ic);
+-            }
+-            return preferTextIcon(label, icon) ? "" : iconName();
+-        }));
+-    FCITX_OBJECT_VTABLE_PROPERTY(
+-        iconPixmap, "IconPixmap", "a(iiay)", ([this]() {
+-            std::vector<dbus::DBusStruct<int, int, std::vector<uint8_t>>>
+-                result;
+-
+-            auto classicui = parent_->classicui();
+-            if (!classicui) {
+-                return result;
+-            }
+-            const auto label = labelText();
+-            if (!label.empty()) {
+-                if (cachedLabel_ == label) {
+-                    result = cachedLabelIcon_;
+-                } else {
+-                    for (unsigned int size : {16, 22, 32, 48}) {
+-                        // swap to network byte order if we are little endian
+-                        auto data =
+-                            classicui->call<IClassicUI::labelIcon>(label, size);
+-                        if (isLittleEndian()) {
+-                            uint32_t *uintBuf =
+-                                reinterpret_cast<uint32_t *>(data.data());
+-                            for (size_t i = 0;
+-                                 i < data.size() / sizeof(uint32_t); ++i) {
+-                                *uintBuf = htobe32(*uintBuf);
+-                                ++uintBuf;
+-                            }
+-                        }
+-                        result.emplace_back(size, size, std::move(data));
+-                    }
+-                    cachedLabel_ = label;
+-                    cachedLabelIcon_ = result;
+-                }
+-            }
+-            return result;
+-        }));
++    FCITX_OBJECT_VTABLE_PROPERTY(iconName, "IconName", "s",
++                                 [this]() { return iconNamePropertyImpl(); });
++    FCITX_OBJECT_VTABLE_PROPERTY(iconPixmap, "IconPixmap", "a(iiay)",
++                                 ([this]() { return iconPixmap(); }));
+     FCITX_OBJECT_VTABLE_PROPERTY(overlayIconName, "OverlayIconName", "s",
+                                  ([]() { return ""; }));
+     FCITX_OBJECT_VTABLE_PROPERTY(
+@@ -218,7 +268,7 @@ public:
+     FCITX_OBJECT_VTABLE_PROPERTY(attentionMovieName, "AttentionMovieName", "s",
+                                  []() { return ""; });
+     FCITX_OBJECT_VTABLE_PROPERTY(tooltip, "ToolTip", "(sa(iiay)ss)",
+-                                 []() { return tooltip(); });
++                                 [this]() { return tooltip(); });
+     FCITX_OBJECT_VTABLE_PROPERTY(itemIsMenu, "ItemIsMenu", "b",
+                                  []() { return false; });
+     FCITX_OBJECT_VTABLE_PROPERTY(menu, "Menu", "o",
+@@ -244,6 +294,7 @@ private:
+     std::string cachedLabel_;
+     std::vector<dbus::DBusStruct<int, int, std::vector<uint8_t>>>
+         cachedLabelIcon_;
++    std::string lastTitle_;
+ };
+
+ NotificationItem::NotificationItem(Instance *instance)
+@@ -286,26 +337,27 @@ void NotificationItem::setRegistered(bool registered) {
+     registered_ = registered;
+
+     if (registered_) {
+-        auto updateIcon = [this](Event &e) {
++        auto updateIconAndTitle = [this](Event &e) {
+             InputContext *ic = nullptr;
+             if (e.isInputContextEvent()) {
+                 ic = dynamic_cast<InputContextEvent &>(e).inputContext();
+             }
+             menu_->updateMenu(ic);
+             newIcon();
++            newToolTip();
+         };
+         for (auto type : {EventType::InputContextFocusIn,
+                           EventType::InputContextSwitchInputMethod,
+                           EventType::InputMethodGroupChanged}) {
+             eventHandlers_.emplace_back(instance_->watchEvent(
+-                type, EventWatcherPhase::Default, updateIcon));
++                type, EventWatcherPhase::Default, updateIconAndTitle));
+         }
+         eventHandlers_.emplace_back(instance_->watchEvent(
+             EventType::InputContextFlushUI, EventWatcherPhase::Default,
+-            [updateIcon](Event &event) {
++            [updateIconAndTitle](Event &event) {
+                 if (static_cast<InputContextFlushUIEvent &>(event)
+                         .component() == UserInterfaceComponent::StatusArea) {
+-                    updateIcon(event);
++                    updateIconAndTitle(event);
+                 }
+             }));
+     }
+@@ -420,6 +472,13 @@ void NotificationItem::newIcon() {
+     // sni_->xayatanaNewLabel(sni_->label(), sni_->label());
+ }
+
++void NotificationItem::newToolTip() {
++    if (!sni_->isRegistered()) {
++        return;
++    }
++    sni_->notifyNewTooltip();
++}
++
+ class NotificationItemFactory : public AddonFactory {
+     AddonInstance *create(AddonManager *manager) override {
+         return new NotificationItem(manager->instance());
+--- fcitx5-community.orig/src/modules/notificationitem/notificationitem.h
++++ fcitx5-community/src/modules/notificationitem/notificationitem.h
+@@ -7,13 +7,18 @@
+ #ifndef _FCITX_MODULES_NOTIFICATIONITEM_NOTIFICATIONITEM_H_
+ #define _FCITX_MODULES_NOTIFICATIONITEM_NOTIFICATIONITEM_H_
+
++#include <cstdint>
+ #include <memory>
++#include <string>
++#include <vector>
++#include "fcitx-utils/dbus/bus.h"
+ #include "fcitx-utils/dbus/servicewatcher.h"
++#include "fcitx-utils/eventloopinterface.h"
++#include "fcitx-utils/handlertable.h"
+ #include "fcitx-utils/trackableobject.h"
+ #include "fcitx/addoninstance.h"
+ #include "fcitx/addonmanager.h"
+ #include "fcitx/instance.h"
+-#include "dbus_public.h"
+ #include "notificationitem_public.h"
+
+ namespace fcitx {
+@@ -37,7 +42,6 @@ public:
+     bool registered() const { return registered_; }
+     std::unique_ptr<HandlerTableEntry<NotificationItemCallback>>
+     watch(NotificationItemCallback callback);
+-    void newIcon();
+     FCITX_ADDON_DEPENDENCY_LOADER(classicui, instance_->addonManager());
+     DBusMenu *menu() { return menu_.get(); }
+
+@@ -50,6 +54,8 @@ private:
+
+     void maybeScheduleRegister();
+     void cleanUp();
++    void newIcon();
++    void newToolTip();
+
+     Instance *instance_;
+     std::unique_ptr<dbus::ServiceWatcher> watcher_;

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -14,3 +14,4 @@
 0015-disable-showInputMethodInformation-by-default.patch
 0016-only-use-first-xkb-layout-for-default-group.patch
 0017-fix-detect-dde-desktop-type-for-XDG_CURRENT_DESKTOP-DDE.patch
+0018-show-current-input-method-name-in-sni-tooltip.patch


### PR DESCRIPTION
Backport upstream tooltip implementation so the dock/tray icon shows the active input method name on hover.

移植上游 SNI tooltip 实现，dock 托盘图标悬停显示当前输入法名称。

Log: 添加输入法名 tooltip 补丁
PMS: BUG-324005
Influence: dock 图标悬停时显示当前输入法名称，提升用户辨识体验。