### PR TITLE
fix(xcb): exhaust event queue before blocking to avoid missed events

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+fcitx5 (5.1.12-2deepin7) unstable; urgency=medium
+
+  * debian/patches: add 0019-exhaust-xcb-event-queue-before-blocking.patch.
+  * Backport upstream 5a875292: fix rare missed xcb events (#1304).
+
+ -- Wang Yu <wangyu@uniontech.com>  Mon, 22 Jun 2026 14:33:46 +0800
+
 fcitx5 (5.1.12-2deepin6) unstable; urgency=medium
 
   * debian/patches: add 0018-show-current-input-method-name-in-sni-tooltip.patch.

--- a/debian/patches/0019-exhaust-xcb-event-queue-before-blocking.patch
+++ b/debian/patches/0019-exhaust-xcb-event-queue-before-blocking.patch
@@ -1,0 +1,44 @@
+From: Weng Xuetian <wengxt@gmail.com>
+Date: Tue, 25 Mar 2025 23:40:52 -0700
+Subject: [PATCH] Ensure we exhaust the xcb event queue before back to blocking.
+
+We added xcb_flush when we introduce postEvent. However, we only try to
+exhaust xcb event queue on if it is triggered by a xcb event. In some rare
+case, we may missed some xcb event to be processed.
+
+Fix #1304.
+
+Origin: upstream, commit 5a8752922f34539da621bf65e78e094789eab573
+Bug: https://github.com/fcitx/fcitx5/issues/1304
+---
+ src/modules/xcb/xcbconnection.cpp  | 1 -
+ src/modules/xcb/xcbeventreader.cpp | 1 +
+ 2 files changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/modules/xcb/xcbconnection.cpp b/src/modules/xcb/xcbconnection.cpp
+index b4c1cfe0..a5d7d782 100644
+--- a/src/modules/xcb/xcbconnection.cpp
++++ b/src/modules/xcb/xcbconnection.cpp
+@@ -348,7 +348,6 @@ void XCBConnection::processEvent() {
+             }
+         }
+     }
+-    reader_->wakeUp();
+ }
+
+ bool XCBConnection::filterEvent(xcb_connection_t *,
+diff --git a/src/modules/xcb/xcbeventreader.cpp b/src/modules/xcb/xcbeventreader.cpp
+index 58f85744..041d4677 100644
+--- a/src/modules/xcb/xcbeventreader.cpp
++++ b/src/modules/xcb/xcbeventreader.cpp
+@@ -21,6 +21,7 @@ XCBEventReader::XCBEventReader(XCBConnection *conn)
+             }
+             FCITX_XCB_DEBUG() << "xcb_flush";
+             xcb_flush(conn_->connection());
++            wakeUp();
+             return true;
+         });
+     thread_ = std::make_unique<std::thread>(&XCBEventReader::runThread, this);
+--
+2.45.2
+

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -15,3 +15,4 @@
 0016-only-use-first-xkb-layout-for-default-group.patch
 0017-fix-detect-dde-desktop-type-for-XDG_CURRENT_DESKTOP-DDE.patch
 0018-show-current-input-method-name-in-sni-tooltip.patch
+0019-exhaust-xcb-event-queue-before-blocking.patch


### PR DESCRIPTION
Backport upstream 5a875292. Move wakeUp() right after xcb_flush in the reader thread so it self-wakes every postEvent round, instead of relying on the main thread's processEvent() to wake the reader.

移植上游 5a875292。将 wakeUp() 移至 reader 线程 xcb_flush 之后，使每轮 postEvent 自唤醒，不再依赖主线程 processEvent() 触发。

Log: 移植上游 xcb 事件队列排空修复
Influence: 修复偶发 xcb 事件漏处理导致输入法响应丢失问题。