### PR TITLE
fix(dbusfrontend): refresh client UI after virtual keyboard switch

### DIFF
--- a/debian/patches/0021-support-client-virtual-keyboard-show.patch
+++ b/debian/patches/0021-support-client-virtual-keyboard-show.patch
@@ -1,0 +1,23 @@
+Index: src/frontend/dbusfrontend/dbusfrontend.cpp
+===================================================================
+--- a/src/frontend/dbusfrontend/dbusfrontend.cpp
++++ b/src/frontend/dbusfrontend/dbusfrontend.cpp
+@@ -573,9 +588,17 @@ DBusFrontendModule::DBusFrontendModule(I
+         }));
+     events_.emplace_back(instance_->watchEvent(
+         EventType::UIChanged, EventWatcherPhase::Default, [this](Event &) {
+-            instance_->inputContextManager().foreach([](InputContext *ic) {
++            instance_->inputContextManager().foreach([this](InputContext *ic) {
+                 if (ic->frontendName() == "dbus") {
+                     static_cast<DBusInputContext1 *>(ic)->updateCapability();
++                    if (ic->capabilityFlags().test(
++                            CapabilityFlag::ClientSideInputPanel) &&
++                        instance_->currentUI() == "virtualkeyboard" &&
++                        !ic->inputPanel().empty()) {
++                        ic->inputPanel().reset();
++                        static_cast<DBusInputContext1 *>(ic)
++                            ->updateClientSideUIImpl();
++                    }
+                 }
+                 return true;
+             });

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -16,3 +16,4 @@
 0017-fix-detect-dde-desktop-type-for-XDG_CURRENT_DESKTOP-DDE.patch
 0018-show-current-input-method-name-in-sni-tooltip.patch
 0019-exhaust-xcb-event-queue-before-blocking.patch
+0021-support-client-virtual-keyboard-show.patch


### PR DESCRIPTION
Reset client-side input panels when the virtual keyboard UI becomes active. 虚拟键盘 UI 激活时重置客户端侧输入面板，确保其使用新的 UI。

Log: 虚拟键盘UI切换后刷新客户端输入面板
Influence: 使用客户端输入面板的应用切换到虚拟键盘后可正确刷新界面。