### PR TITLE
feat(virtualkeyboard): add configurable display control

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+fcitx5 (5.1.12-2deepin8) unstable; urgency=medium
+
+  * debian/patches: add virtual keyboard client UI and configuration patches.
+  * Add configurable virtual keyboard display control.
+
+ -- Wang Yu <wangyu@uniontech.com>  Tue, 14 Jul 2026 16:38:31 +0800
+
 fcitx5 (5.1.12-2deepin7) unstable; urgency=medium
 
   * debian/patches: add 0019-exhaust-xcb-event-queue-before-blocking.patch.

--- a/debian/patches/0022-add-configurable-virtualkeyboard-addon.patch
+++ b/debian/patches/0022-add-configurable-virtualkeyboard-addon.patch
@@ -1,0 +1,317 @@
+Index: src/ui/virtualkeyboard/virtualkeyboard.conf.in.in
+===================================================================
+--- a/src/ui/virtualkeyboard/virtualkeyboard.conf.in.in
++++ b/src/ui/virtualkeyboard/virtualkeyboard.conf.in.in
+@@ -5,6 +5,7 @@
+ Library=libvirtualkeyboard
+ Category=UI
+ Version=@PROJECT_VERSION@
++Configurable=True
+ UIPriority=0
+ OnDemand=True
+ UIType=OnScreenKeyboard
+Index: src/ui/virtualkeyboard/virtualkeyboard.cpp
+===================================================================
+--- a/src/ui/virtualkeyboard/virtualkeyboard.cpp
++++ b/src/ui/virtualkeyboard/virtualkeyboard.cpp
+@@ -212,6 +212,7 @@
+ VirtualKeyboard::VirtualKeyboard(Instance *instance)
+     : instance_(instance), bus_(dbus()->call<IDBusModule::bus>()),
+       watcher_(*bus_) {
++    reloadConfig();
+     entry_ = watcher_.watchService(
+         VirtualKeyboardName, [this](const std::string &, const std::string &,
+                                     const std::string &newOwner) {
+@@ -226,6 +227,25 @@
+ 
+ VirtualKeyboard::~VirtualKeyboard() = default;
+ 
++const Configuration *VirtualKeyboard::getConfig() const { return &config_; }
++
++void VirtualKeyboard::setConfig(const RawConfig &config) {
++    config_.load(config, true);
++    safeSaveAsIni(config_, "conf/virtualkeyboard.conf");
++    updateInputMethodMode();
++}
++
++void VirtualKeyboard::reloadConfig() {
++    readAsIni(config_, "conf/virtualkeyboard.conf");
++    updateInputMethodMode();
++}
++
++void VirtualKeyboard::updateInputMethodMode() {
++    instance_->setInputMethodMode(config_.enableVirtualKeyboard.value()
++                                      ? InputMethodMode::OnScreenKeyboard
++                                      : InputMethodMode::PhysicalKeyboard);
++}
++
+ void VirtualKeyboard::suspend() {
+     if (auto *sni = notificationitem()) {
+         sni->call<INotificationItem::disable>();
+@@ -288,7 +308,7 @@
+ }
+ 
+ void VirtualKeyboard::showVirtualKeyboard() {
+-    if (!available_) {
++    if (!config_.enableVirtualKeyboard.value() || !available_) {
+         return;
+     }
+ 
+@@ -316,6 +336,10 @@
+ }
+ 
+ void VirtualKeyboard::showVirtualKeyboardForcibly() {
++    if (!config_.enableVirtualKeyboard.value()) {
++        return;
++    }
++
+     if (!available_) {
+         return;
+     }
+Index: src/ui/virtualkeyboard/virtualkeyboard.h
+===================================================================
+--- a/src/ui/virtualkeyboard/virtualkeyboard.h
++++ b/src/ui/virtualkeyboard/virtualkeyboard.h
+@@ -7,7 +7,10 @@
+ #ifndef _FCITX_UI_VIRTUALKEYBOARD_VIRTUALKEYBOARD_H_
+ #define _FCITX_UI_VIRTUALKEYBOARD_VIRTUALKEYBOARD_H_
+ 
++#include "fcitx-config/configuration.h"
++#include "fcitx-config/iniparser.h"
+ #include "fcitx-utils/dbus/servicewatcher.h"
++#include "fcitx-utils/i18n.h"
+ #include "fcitx/addonfactory.h"
+ #include "fcitx/addoninstance.h"
+ #include "fcitx/addonmanager.h"
+@@ -20,12 +23,20 @@
+ class VirtualKeyboardBackend;
+ class VirtualKeyboardService;
+ 
++FCITX_CONFIGURATION(VirtualKeyboardConfig,
++                    Option<bool> enableVirtualKeyboard{
++                        this, "EnableVirtualKeyboard",
++                        _("Force virtual keyboard"), false};);
++
+ class VirtualKeyboard : public VirtualKeyboardUserInterface {
+ public:
+     VirtualKeyboard(Instance *instance);
+     ~VirtualKeyboard();
+ 
+     Instance *instance() { return instance_; }
++    const Configuration *getConfig() const override;
++    void setConfig(const RawConfig &config) override;
++    void reloadConfig() override;
+     void suspend() override;
+     void resume() override;
+     bool available() override { return available_; }
+@@ -47,6 +58,7 @@
+ 
+ private:
+     void initVirtualKeyboardService();
++    void updateInputMethodMode();
+ 
+     void setAvailable(bool available);
+ 
+@@ -85,6 +97,7 @@
+         eventHandlers_;
+     bool available_ = false;
+     bool visible_ = false;
++    VirtualKeyboardConfig config_;
+ };
+ } // namespace fcitx
+ 
+Index: po/fcitx5.pot
+===================================================================
+--- a/po/fcitx5.pot
++++ b/po/fcitx5.pot
+@@ -103,6 +103,10 @@
+ msgid "A virtual keyboard backend based on DBus"
+ msgstr ""
+ 
++#: src/ui/virtualkeyboard/virtualkeyboard.h:31
++msgid "Force virtual keyboard"
++msgstr ""
++
+ #: src/ui/classic/theme.h:210
+ msgid "Accent Colors"
+ msgstr ""
+Index: po/zh_CN.po
+===================================================================
+--- a/po/zh_CN.po
++++ b/po/zh_CN.po
+@@ -111,6 +111,10 @@
+ msgid "A virtual keyboard backend based on DBus"
+ msgstr "一个基于 DBus 的虚拟键盘后端"
+ 
++#: src/ui/virtualkeyboard/virtualkeyboard.h:31
++msgid "Force virtual keyboard"
++msgstr "强制使用虚拟键盘"
++
+ #: src/ui/classic/theme.h:210
+ msgid "Accent Colors"
+ msgstr "重点色"
+Index: po/zh_TW.po
+===================================================================
+--- a/po/zh_TW.po
++++ b/po/zh_TW.po
+@@ -117,6 +117,10 @@
+ msgid "A virtual keyboard backend based on DBus"
+ msgstr "一個基於 DBus 的虛擬鍵盤後端"
+ 
++#: src/ui/virtualkeyboard/virtualkeyboard.h:31
++msgid "Force virtual keyboard"
++msgstr "強制使用虛擬鍵盤"
++
+ #: src/ui/classic/theme.h:210
+ msgid "Accent Colors"
+ msgstr "強調色"
+Index: po/ca.po
+===================================================================
+--- a/po/ca.po
++++ b/po/ca.po
+@@ -108,6 +108,10 @@
+ msgid "A virtual keyboard backend based on DBus"
+ msgstr ""
+ 
++#: src/ui/virtualkeyboard/virtualkeyboard.h:31
++msgid "Force virtual keyboard"
++msgstr "Força l'ús del teclat virtual"
++
+ #: src/ui/classic/theme.h:210
+ msgid "Accent Colors"
+ msgstr ""
+Index: po/da.po
+===================================================================
+--- a/po/da.po
++++ b/po/da.po
+@@ -108,6 +108,10 @@
+ msgid "A virtual keyboard backend based on DBus"
+ msgstr ""
+ 
++#: src/ui/virtualkeyboard/virtualkeyboard.h:31
++msgid "Force virtual keyboard"
++msgstr ""
++
+ #: src/ui/classic/theme.h:210
+ msgid "Accent Colors"
+ msgstr ""
+Index: po/de.po
+===================================================================
+--- a/po/de.po
++++ b/po/de.po
+@@ -110,6 +110,10 @@
+ msgid "A virtual keyboard backend based on DBus"
+ msgstr "Eine virtuelle Tastatur basierend auf DBus"
+ 
++#: src/ui/virtualkeyboard/virtualkeyboard.h:31
++msgid "Force virtual keyboard"
++msgstr "Virtuelle Tastatur erzwingen"
++
+ #: src/ui/classic/theme.h:210
+ msgid "Accent Colors"
+ msgstr ""
+Index: po/es.po
+===================================================================
+--- a/po/es.po
++++ b/po/es.po
+@@ -106,6 +106,10 @@
+ msgid "A virtual keyboard backend based on DBus"
+ msgstr ""
+ 
++#: src/ui/virtualkeyboard/virtualkeyboard.h:31
++msgid "Force virtual keyboard"
++msgstr "Forzar teclado virtual"
++
+ #: src/ui/classic/theme.h:210
+ msgid "Accent Colors"
+ msgstr ""
+Index: po/fr.po
+===================================================================
+--- a/po/fr.po
++++ b/po/fr.po
+@@ -109,6 +109,10 @@
+ msgid "A virtual keyboard backend based on DBus"
+ msgstr ""
+ 
++#: src/ui/virtualkeyboard/virtualkeyboard.h:31
++msgid "Force virtual keyboard"
++msgstr "Forcer le clavier virtuel"
++
+ #: src/ui/classic/theme.h:210
+ msgid "Accent Colors"
+ msgstr ""
+Index: po/he.po
+===================================================================
+--- a/po/he.po
++++ b/po/he.po
+@@ -109,6 +109,10 @@
+ msgid "A virtual keyboard backend based on DBus"
+ msgstr ""
+ 
++#: src/ui/virtualkeyboard/virtualkeyboard.h:31
++msgid "Force virtual keyboard"
++msgstr "כפה מקלדת וירטואלית"
++
+ #: src/ui/classic/theme.h:210
+ msgid "Accent Colors"
+ msgstr ""
+Index: po/ja.po
+===================================================================
+--- a/po/ja.po
++++ b/po/ja.po
+@@ -110,6 +110,10 @@
+ msgid "A virtual keyboard backend based on DBus"
+ msgstr "DBus ベースの仮想キーボードバックエンド"
+ 
++#: src/ui/virtualkeyboard/virtualkeyboard.h:31
++msgid "Force virtual keyboard"
++msgstr "仮想キーボードを強制する"
++
+ #: src/ui/classic/theme.h:210
+ msgid "Accent Colors"
+ msgstr "アクセントカラー"
+Index: po/ko.po
+===================================================================
+--- a/po/ko.po
++++ b/po/ko.po
+@@ -111,6 +111,10 @@
+ msgid "A virtual keyboard backend based on DBus"
+ msgstr ""
+ 
++#: src/ui/virtualkeyboard/virtualkeyboard.h:31
++msgid "Force virtual keyboard"
++msgstr "가상 키보드 강제 사용"
++
+ #: src/ui/classic/theme.h:210
+ msgid "Accent Colors"
+ msgstr ""
+Index: po/ru.po
+===================================================================
+--- a/po/ru.po
++++ b/po/ru.po
+@@ -111,6 +111,10 @@
+ msgid "A virtual keyboard backend based on DBus"
+ msgstr "Серверная часть виртуальной клавиатуры на основе DBus"
+ 
++#: src/ui/virtualkeyboard/virtualkeyboard.h:31
++msgid "Force virtual keyboard"
++msgstr "Принудительно использовать виртуальную клавиатуру"
++
+ #: src/ui/classic/theme.h:210
+ msgid "Accent Colors"
+ msgstr "Акцентные цвета"
+Index: po/vi.po
+===================================================================
+--- a/po/vi.po
++++ b/po/vi.po
+@@ -107,6 +107,10 @@
+ msgid "A virtual keyboard backend based on DBus"
+ msgstr ""
+ 
++#: src/ui/virtualkeyboard/virtualkeyboard.h:31
++msgid "Force virtual keyboard"
++msgstr "Buộc sử dụng bàn phím ảo"
++
+ #: src/ui/classic/theme.h:210
+ msgid "Accent Colors"
+ msgstr ""

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -17,3 +17,4 @@
 0018-show-current-input-method-name-in-sni-tooltip.patch
 0019-exhaust-xcb-event-queue-before-blocking.patch
 0021-support-client-virtual-keyboard-show.patch
+0022-add-configurable-virtualkeyboard-addon.patch


### PR DESCRIPTION
Add an EnableVirtualKeyboard option that gates all virtual keyboard show paths. 新增 EnableVirtualKeyboard 配置，统一控制所有虚拟键盘显示入口。

Log: 添加虚拟键盘显示开关
Influence: 关闭开关时不再显示虚拟键盘；开启后保留原有显示能力。