### PR TITLE
fix(wayland): suppress diagnostic prompts on Deepin

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+fcitx5 (5.1.12-2deepin10) unstable; urgency=medium
+
+  * debian/patches: add 0023-block-wayland-diagnostic-prompt-on-deepin.patch.
+  * Suppress Wayland diagnostic prompts in the Deepin desktop environment.
+
+ -- Wang Yu <wangyu@uniontech.com>  Fri, 7 Aug 2026 14:30:00 +0800
+
 fcitx5 (5.1.12-2deepin9) unstable; urgency=medium
 
   * debian/patches: fix virtual keyboard show/restart/load/translation issues in 0022.

--- a/debian/patches/0023-block-wayland-diagnostic-prompt-on-deepin.patch
+++ b/debian/patches/0023-block-wayland-diagnostic-prompt-on-deepin.patch
@@ -1,0 +1,18 @@
+Description: Suppress Wayland diagnostics on Deepin
+ Deepin has requested that Fcitx not display Wayland diagnostic messages in
+ its desktop environment.
+Author: groveer <guoyao@uniontech.com>
+Origin: upstream, https://github.com/fcitx/fcitx5/pull/1629
+Last-Update: 2026-08-07
+
+--- a/src/modules/wayland/waylandmodule.cpp
++++ b/src/modules/wayland/waylandmodule.cpp
+@@ -637,6 +637,8 @@ void WaylandModule::selfDiagnose() {
+                   "see "
+                   "https://fcitx-im.org/wiki/Using_Fcitx_5_on_Wayland#GNOME"));
+         }
++    } else if (desktop == DesktopType::DEEPIN) {
++        // Per Deepin upstream request, do not show this message for them.
+     } else {
+         // It is not clear whether compositor is supported, only warn if wayland
+         // im is being used..

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -18,3 +18,4 @@
 0019-exhaust-xcb-event-queue-before-blocking.patch
 0021-support-client-virtual-keyboard-show.patch
 0022-add-configurable-virtualkeyboard-addon.patch
+0023-block-wayland-diagnostic-prompt-on-deepin.patch


### PR DESCRIPTION
Suppress unsupported Wayland diagnostic messages in the Deepin desktop.

在Deepin桌面环境中屏蔽不适用的Wayland诊断提示。

Log: 屏蔽Deepin下的Wayland诊断提示
Influence: Deepin用户不再收到Wayland诊断通知。