### PR TITLE
fix: preserve current input method when updating input method group

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+fcitx5 (5.1.12-2deepin11) unstable; urgency=medium
+
+  * debian/patches: add 0024-preserve-current-im-when-updating-input-method-group.patch.
+  * Preserve the current input method when updating the input method group.
+
+ -- Wang Yu <wangyu@uniontech.com>  Sun, 10 Aug 2026 13:20:00 +0800
+
 fcitx5 (5.1.12-2deepin10) unstable; urgency=medium
 
   * debian/patches: add 0023-block-wayland-diagnostic-prompt-on-deepin.patch.

--- a/debian/patches/0024-preserve-current-im-when-updating-input-method-group.patch
+++ b/debian/patches/0024-preserve-current-im-when-updating-input-method-group.patch
@@ -1,0 +1,87 @@
+Description: Preserve current input method when updating input method group
+ When replacing the input method group without specifying a default, keep
+ the previous group's default instead of unconditionally resetting to the
+ second list entry. Also drop the redundant forced reset in the D-Bus
+ handler so the selection is deferred to the input method manager.
+Author: wangyu <wangyu@uniontech.com>
+Forwarded: not-needed
+Last-Update: 2026-08-10
+
+diff --git a/src/lib/fcitx/inputmethodmanager.cpp b/src/lib/fcitx/inputmethodmanager.cpp
+index 35675a1..f623c83 100644
+--- a/src/lib/fcitx/inputmethodmanager.cpp
++++ b/src/lib/fcitx/inputmethodmanager.cpp
+@@ -351,7 +351,11 @@ void InputMethodManager::setGroup(InputMethodGroup newGroupInfo) {
+                                    return !d->entries_.count(item.name());
+                                });
+     list.erase(iter, list.end());
+-    newGroupInfo.setDefaultInputMethod(newGroupInfo.defaultInputMethod());
++    auto defaultInputMethod = newGroupInfo.defaultInputMethod();
++    if (defaultInputMethod.empty()) {
++        defaultInputMethod = group->defaultInputMethod();
++    }
++    newGroupInfo.setDefaultInputMethod(defaultInputMethod);
+     *group = std::move(newGroupInfo);
+     if (!d->buildingGroup_ && isCurrent) {
+         emit<InputMethodManager::CurrentGroupChanged>(d->groupOrder_.front());
+diff --git a/src/modules/dbus/dbusmodule.cpp b/src/modules/dbus/dbusmodule.cpp
+index bb46e99..bf406c4 100644
+--- a/src/modules/dbus/dbusmodule.cpp
++++ b/src/modules/dbus/dbusmodule.cpp
+@@ -252,7 +252,6 @@ public:
+                 InputMethodGroupItem(std::get<0>(entry))
+                     .setLayout(std::get<1>(entry)));
+         }
+-        group.setDefaultInputMethod("");
+         imManager.setGroup(std::move(group));
+         imManager.save();
+     }
+diff --git a/test/testinstance.cpp b/test/testinstance.cpp
+index 00a3268..9e459fa 100644
+--- a/test/testinstance.cpp
++++ b/test/testinstance.cpp
+@@ -54,6 +54,36 @@ void testReloadGlobalConfig(Instance &instance) {
+     });
+ }
+ 
++void testSetGroupDefaultInputMethod(Instance &instance) {
++    instance.eventDispatcher().schedule([&instance]() {
++        auto &imManager = instance.inputMethodManager();
++        auto group = imManager.currentGroup();
++        group.inputMethodList().clear();
++        group.inputMethodList().emplace_back("keyboard-us");
++        group.inputMethodList().emplace_back("testim");
++        group.setDefaultInputMethod("testim");
++        imManager.setGroup(group);
++        FCITX_ASSERT(imManager.currentGroup().defaultInputMethod() == "testim");
++
++        InputMethodGroup replacement(group.name());
++        replacement.inputMethodList().emplace_back("keyboard-us");
++        replacement.inputMethodList().emplace_back("testim");
++        imManager.setGroup(std::move(replacement));
++        FCITX_ASSERT(imManager.currentGroup().defaultInputMethod() == "testim");
++
++        InputMethodGroup invalidDefault(group.name());
++        invalidDefault.inputMethodList().emplace_back("keyboard-us");
++        invalidDefault.inputMethodList().emplace_back("testim2");
++        imManager.setGroup(std::move(invalidDefault));
++        FCITX_ASSERT(imManager.currentGroup().defaultInputMethod() == "testim2");
++
++        InputMethodGroup fallback(group.name());
++        fallback.inputMethodList().emplace_back("keyboard-us");
++        imManager.setGroup(std::move(fallback));
++        FCITX_ASSERT(imManager.currentGroup().defaultInputMethod() == "keyboard-us");
++    });
++}
++
+ void testModifierOnlyHotkey(Instance &instance) {
+     instance.eventDispatcher().schedule([&instance]() {
+         auto defaultGroup = instance.inputMethodManager().currentGroup();
+@@ -135,6 +165,7 @@ int main() {
+     FCITX_ASSERT(instance.addonManager().addonOptions("name3") ==
+                  std::vector<std::string>{});
+     testCheckUpdate(instance);
++    testSetGroupDefaultInputMethod(instance);
+     testReloadGlobalConfig(instance);
+     testModifierOnlyHotkey(instance);
+     instance.eventDispatcher().schedule([&instance]() { instance.exit(); });

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -19,3 +19,4 @@
 0021-support-client-virtual-keyboard-show.patch
 0022-add-configurable-virtualkeyboard-addon.patch
 0023-block-wayland-diagnostic-prompt-on-deepin.patch
+0024-preserve-current-im-when-updating-input-method-group.patch


### PR DESCRIPTION
## Root Cause

When adding, removing, or moving input methods via the control center, the
configuration tool calls `SetInputMethodGroupInfo` which unconditionally
resets the default input method by calling `group.setDefaultInputMethod("")`.
Under the zh_CN default list `[keyboard-layout, pinyin, rime, sogou]`, index
1 is Pinyin, so the active input method switches to Pinyin after the
operation.

## Fix

Backport two upstream patches into a single debian patch:

- [fcitx5/fcitx5#1624](https://github.com/fcitx/fcitx5/pull/1624): In
  `InputMethodManager::setGroup`, when the replacement group does not
  specify a default input method (empty), keep the previous group's default.
- [fcitx5/fcitx5#1633](https://github.com/fcitx/fcitx5/pull/1633): Remove
  the redundant `group.setDefaultInputMethod("")` call in the D-Bus handler,
  deferring default selection to `setGroup`.

After the fix, adding/removing/moving input methods in the control center
no longer changes the active input method. No changes needed in the
configuration tool plugin.

## Safety Assessment

**Low risk**. No function signature changes, no public API removal. The
`setGroup` change only affects replacement groups with an unspecified
default (keeping the old value instead of resetting to index 1), matching
upstream behavior. The `dbusmodule.cpp` change is a pure removal of one
line. Upstream #1624 includes a regression unit test.
